### PR TITLE
fix typo in ch01.md

### DIFF
--- a/ch01.md
+++ b/ch01.md
@@ -210,7 +210,7 @@
 - **_可演化性（Evolvability）_**
   便于后面需求快速适配：避免耦合过紧，将代码绑定到某种实现上。也称为**可扩展性（extensibility）**，**可修改性（modifiability）**  或**可塑性（plasticity）**。
 
-## **可维护性（Operability）：人生苦短，关爱运维**
+## **可操作性（Operability）：人生苦短，关爱运维**
 
 有效的运维绝对是个高技术活：
 


### PR DESCRIPTION
fix typo: "可维护性”——>“可操作性”